### PR TITLE
feat: Offload model-making to gen-experiments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,8 @@ dynamic = ["version"]
 dependencies = [
   "mitosis>=0.3.0",
   "pysindy[cvxpy] @ git+https://github.com/dynamicslab/pysindy@trapping-plumes",
-  "matplotlib"
+  "matplotlib",
+  "pysindy-experiments @ git+https://github.com/Jacob-Stevens-Haas/gen-experiments"
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
This uses the make_model function from my other package in order to allow creating a complete model from dictionary arguments, rather than complete objects.

Going to continue working on it now, but adding it as a pull request in case you have a dirty main and potentially merge conflicts.  Doing it in a PR would still show the same conflict as if I had merged locally and pushed my updated `main` here, but this way might make it easier to reason about.