### PR TITLE
hotfix: get_coef_acc divide by zero

### DIFF
--- a/plumex/regression_pipeline.py
+++ b/plumex/regression_pipeline.py
@@ -152,7 +152,10 @@ def get_coef_acc(
         _, r_x_y = train_val_set[i]
 
         xy_true, xy_pred = _get_true_pred(f,r_x_y, regression_method)
-        accs[i] = 1 - np.linalg.norm(xy_true-xy_pred)/np.linalg.norm(xy_true)
+        if len(xy_true) == 0:
+            accs[i] = np.nan
+        else:
+            accs[i] = 1 - np.linalg.norm(xy_true-xy_pred)/np.linalg.norm(xy_true)
     
     return accs
 

--- a/plumex/tests/test_regression_pipeline.py
+++ b/plumex/tests/test_regression_pipeline.py
@@ -26,6 +26,15 @@ def test_get_coef_acc():
 
     np.testing.assert_array_almost_equal(expected,result)
 
+    # empty 
+    train_val_set = [
+        (1,r_x_y_1),
+        (2,r_x_y_2[np.array([False for _ in range(3)])])
+    ]
+    expected = np.array([1,np.nan])
+    result = get_coef_acc(coef_time_series, train_val_set,regression_method='poly')
+    np.testing.assert_array_almost_equal(expected,result)
+
 def test_split_into_train_val():
     train_i = np.arange(6)+4
     frame_train = np.vstack((train_i, train_i, train_i)).T


### PR DESCRIPTION
In `plumex.regression_pipeline`, there are cases where train_val_set can have `PlumePoints` that are empty arrays. In such cases, a `ZeroDivisionError` occurs when calculating accuracy. Return np.nan value which is dealt with a posteriori.