### PR TITLE
Let SINDy and DMD experiments work with any number of coefficients

### DIFF
--- a/plumex/config.py
+++ b/plumex/config.py
@@ -66,6 +66,10 @@ data_lookup = {
         "lo1pts": "step1/3ac8b5.dill",
         "hi1pts": "step1/abb562.dill",
         "hi2pts": "step1/d32d3b.dill",
+        "lin-win": "step2/linear.dill",
+        "ppara-win": "step2/poly_para.dill",
+        "pinv-win": "step2/poly_inv.dill",
+        "poly-win": "step2/poly.dill",
     },
     "fixed_range": {
         "test": 200,

--- a/plumex/hankel_pipeline.py
+++ b/plumex/hankel_pipeline.py
@@ -31,6 +31,7 @@ def run(
     #################
     # Preprocessing #
     #################
+    _, n_feat = data.shape
     metrics = {}
     scalar = StandardScaler()
     if normalize:
@@ -129,7 +130,7 @@ def run(
     ############
     # plot time_series
     t = np.arange(len(data))
-    feature_names = ["a", "b", "c"]
+    feature_names = [chr(i) for i in range(97, 97 + n_feat)]
     plot_time_series(t, data=data, feature_names=feature_names, **time_series_kws)
     plt.show()
 
@@ -255,7 +256,7 @@ def _get_variances_modes(
     """
 
     S[::-1].sort()
-    var_sums = np.array([np.sum(S[:i]) for i in range(len(S))]) / np.sum(S)
+    var_sums = np.cumsum(S) / np.sum(S)
 
     mode_indices = []
     vars_captured = []

--- a/plumex/plotting.py
+++ b/plumex/plotting.py
@@ -10,6 +10,7 @@ from matplotlib.figure import Figure
 from matplotlib.gridspec import GridSpec
 
 from .types import Float1D
+from .types import Float2D
 from .types import PolyData
 
 CMAP = mpl.color_sequences["tab10"]
@@ -21,23 +22,24 @@ BGROUND = mcolors.CSS4_COLORS["lightgrey"]
 
 
 def plot_smoothing_step(
-    t: Float1D, data: PolyData, smooth_data: PolyData, feature_names: list[str]
+    t: Float1D, data: Float2D, smooth_data: Float2D, feature_names: list[str]
 ) -> Figure:
+    n_feat = len(feature_names)
     bigfig = plt.figure(figsize=(12, 12), layout="constrained")
-    gs = GridSpec(3, 3, figure=bigfig)
+    gs = GridSpec(3, n_feat, figure=bigfig)
     compare_fig = bigfig.add_subfigure(gs[0, :])
     zoom_fig = bigfig.add_subfigure(gs[1, :])
     fft_fig = bigfig.add_subfigure(gs[2, :])
     for i, feat in enumerate(feature_names):
-        ax = compare_fig.add_subplot(1, 3, 1 + i)
+        ax = compare_fig.add_subplot(1, n_feat, 1 + i)
         ax.plot(t, data[:, i], label="Data", color=CMEAS)
         ax.plot(t, smooth_data[:, i], label="Smoothed", color=CSMOOTH)
         ax.set_xticks([])
         ax.set_title(f"Coeff {feat}")
-        ax_zoom = zoom_fig.add_subplot(1, 3, 1 + i)
+        ax_zoom = zoom_fig.add_subplot(1, n_feat, 1 + i)
         ax_zoom.plot(t, smooth_data[:, i], color=CSMOOTH)
         ax_zoom.set_xlabel("Time")
-        ax_fft = fft_fig.add_subplot(1, 3, 1 + i)
+        ax_fft = fft_fig.add_subplot(1, n_feat, 1 + i)
         freqs = np.fft.rfftfreq(len(t))
         data_psd = np.abs(np.fft.rfft(data[:, i])) ** 2
         smooth_psd = np.abs(np.fft.rfft(smooth_data[:, i])) ** 2
@@ -55,14 +57,15 @@ def plot_smoothing_step(
 
 
 def plot_predictions(
-    t: Float1D, x_dot_est: PolyData, x_dot_pred: PolyData, feature_names: list[str]
+    t: Float1D, x_dot_est: Float2D, x_dot_pred: Float2D, feature_names: list[str]
 ) -> Figure:
+    n_feat = len(feature_names)
     bigfig = plt.figure(figsize=(12, 8), layout="constrained")
-    gs = GridSpec(2, 3, figure=bigfig)
+    gs = GridSpec(2, n_feat, figure=bigfig)
     plot_fig = bigfig.add_subfigure(gs[0, :])
     scat_fig = bigfig.add_subfigure(gs[1, :])
     for i, feat in enumerate(feature_names):
-        ax = plot_fig.add_subplot(1, 3, 1 + i)
+        ax = plot_fig.add_subplot(1, n_feat, 1 + i)
         ax.plot(t, x_dot_est[:, i], label=r"Smoothed", color=CSMOOTH)
         ax.plot(t, x_dot_pred[:, i], label=r"SINDy predicted", color=CEST)
         ax.set_title(f"Coeff {feat} dot")
@@ -70,7 +73,7 @@ def plot_predictions(
     bigfig.axes[0].legend()
     plot_fig.suptitle("Time Series Derivative Accuracy")
     for i, feat in enumerate(feature_names):
-        ax = scat_fig.add_subplot(1, 3, 1 + i)
+        ax = scat_fig.add_subplot(1, n_feat, 1 + i)
         ax.axhline(0, color="black")
         ax.axvline(0, color="black")
         ax.scatter(x=x_dot_est[:, i], y=x_dot_pred[:, i])
@@ -94,13 +97,14 @@ def print_diagnostics(t: Float1D, model: ps.SINDy, precision: int) -> None:
 
 
 def plot_simulation(
-    t: Float1D, x_true: PolyData, x_sim: PolyData, *, feat_names: list[str], title: str
+    t: Float1D, x_true: Float2D, x_sim: Float2D, *, feat_names: list[str], title: str
 ) -> None:
     """Plot the true vs simulated data"""
+    n_feat = len(feat_names)
     m = min(x_true.shape[0], x_sim.shape[0])
     fig = plt.figure(figsize=(12, 4), layout="constrained")
-    for i in range(x_true.shape[1]):
-        ax = fig.add_subplot(1, x_true.shape[1], 1 + i)
+    for i in range(n_feat):
+        ax = fig.add_subplot(1, n_feat, 1 + i)
         ax.plot(t[:m], x_true[:m, i], "k", label="smoothed data", color=CSMOOTH)
         ax.plot(t[:m], x_sim[:m, i], "r--", label="model simulation", color=CEST)
         ax.set(xlabel="t")

--- a/plumex/plotting.py
+++ b/plumex/plotting.py
@@ -11,7 +11,6 @@ from matplotlib.gridspec import GridSpec
 
 from .types import Float1D
 from .types import Float2D
-from .types import PolyData
 
 CMAP = mpl.color_sequences["tab10"]
 CMEAS = CMAP[0]
@@ -121,11 +120,12 @@ def plot_simulation(
 # Plotting for Hankel Analysis
 def plot_time_series(
     t: Float1D,
-    data: PolyData,
+    data: Float2D,
     feature_names: list[str],
-    smooth_data: Optional[PolyData] = None,
+    smooth_data: Optional[Float2D] = None,
 ) -> Figure:
-    fig, ax = plt.subplots(1, 3, figsize=(15, 5), layout="constrained")
+    n_feat = len(feature_names)
+    fig, ax = plt.subplots(1, n_feat, figsize=(15, 5), layout="constrained")
     for i, feat in enumerate(feature_names):
         ax[i].plot(t, data[:, i], label="Data", color=CMEAS)
 
@@ -233,14 +233,15 @@ def plot_data_and_dmd(
     dmd_data,
     var,
     svd_rank,
-    feature_names,
+    feature_names: list[str],
     smooth_data=None,
     smooth_dmd_data=None,
     var_smooth: float = 0.0,
     svd_rank_smooth=None,
 ):
+    n_feat = len(feature_names)
     if (smooth_data is not None) and (smooth_dmd_data is not None):
-        fig, ax = plt.subplots(3, 2, figsize=(15, 10), layout="constrained")
+        fig, ax = plt.subplots(n_feat, 2, figsize=(15, 10), layout="constrained")
         for i, feat in enumerate(feature_names):
             ax[i][0].plot(t, data[:, i], label="Data", color=CMEAS)
             ax[i][0].plot(t, dmd_data[:, i], label="DMD", color="k")

--- a/plumex/regression_pipeline.py
+++ b/plumex/regression_pipeline.py
@@ -144,6 +144,9 @@ def regress_centerline(
             understood by PLUME.regress_multiframe_mean
         poly_deg: polynomial degree of curve used in regression_method
 
+    Note: Experimental data designed to have a leftwards plume, which informs
+        the poly-inverse method
+
     Returns:
         Experiment results of train and validation accuracy.  "data" key
         is of shape (number of timepoints, number of coefficients in
@@ -158,6 +161,7 @@ def regress_centerline(
         mean_points=train_set_fc,
         regression_method=regression_method,
         poly_deg=poly_deg,
+        direction="left",
         decenter=origin_fc,
     )
 

--- a/plumex/sindy_pipeline.py
+++ b/plumex/sindy_pipeline.py
@@ -79,7 +79,7 @@ def run(
     Returns:
     --------
     err: float
-        normalizing L2 error between time_seris (potentially normalized) and
+        normalizing L2 error between time_series (potentially normalized) and
         solved learned ODE system.
 
     model: pySINDy model

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ name = "pysindy-plume-experiments"
 dynamic = ["version"]
 dependencies = [
   "mitosis>=0.5.2",
+  "pydmd",
   "pysindy[cvxpy] @ git+https://github.com/dynamicslab/pysindy@a43e217",
   "matplotlib",
   "pysindy-experiments @ git+https://github.com/Jacob-Stevens-Haas/gen-experiments@cbaa059",


### PR DESCRIPTION
Follows #27.  A minor PR that relaxes the number of coefficients from 3 to any number within reason.  Some figures had (and have) a hardcoded size, in which case axis lengths are adjusted to fit.  Hence the "within reason"

This PR also adds some config lookups for step 2 (centerline regression) outputs on the blender wind video.  See the results in /home/plumes/trials/dynamics