### PR TITLE
Generate Step 1 and step 2a figures for paper

### DIFF
--- a/plumex/config.py
+++ b/plumex/config.py
@@ -129,6 +129,7 @@ data_lookup = {
         "high": {"kernel_size": 27, "sigma": 9},
     },
     "contour_kws": {
+        "1c": {"num_of_contours": 1},
         "2c": {"num_of_contours": 2},
         "3c": {"num_of_contours": 3},
         "4c": {"num_of_contours": 4},

--- a/plumex/post/__init__.py
+++ b/plumex/post/__init__.py
@@ -1,0 +1,12 @@
+"""Post analysis package.
+
+This contains a variety of scripts to generate final figures from
+trial data.  Modify the module constants for each script if new
+experiments are run.  Run individual scripts to generate respective
+figures/post analysis.  Run this module to generate all figures/post
+analysis.
+"""
+from . import center
+from . import points
+
+__all__ = ["center", "points"]

--- a/plumex/post/__init__.py
+++ b/plumex/post/__init__.py
@@ -7,6 +7,7 @@ figures/post analysis.  Run this module to generate all figures/post
 analysis.
 """
 from . import center
+from . import fig5
 from . import points
 
-__all__ = ["center", "points"]
+__all__ = ["center", "points", "fig5"]

--- a/plumex/post/center.py
+++ b/plumex/post/center.py
@@ -27,7 +27,17 @@ center_trial_keys = {
 }
 train_set = ("lo1", "865", "866", "867", "871", "913", "914", "917", "919", "hi1")
 test_set = ("868", "869", "916", "920", "hi2")
-low_se = ("lo1", "865", "866", "867", "868")
+low_set = ("lo1", "865", "866", "867", "868")
+med_set = ("914", "916", "917", "871")
+hi_set = ("hi1", "hi2", "919", "920")
+full_methods = {
+    "lin": "Linear",
+    "poly": "Polynomial",
+    "poly_para": "Parametric Quadratic",
+    "poly_inv_pin": "Square-Root",
+}
+
+
 trials_folder = Path(__file__).absolute().parents[2] / "trials"
 center_trials_dir = trials_folder / "center-regress"
 center_trial_data: dict[str, MultiRegressionResults] = {
@@ -46,13 +56,11 @@ def get_scores(res: MultiRegressionResults) -> dict[str, Float1D]:
         "lin": _get_non_nan_scores(res["regressions"]["linear"]),
         "poly": _get_non_nan_scores(res["regressions"]["poly"]),
         "poly_para": _get_non_nan_scores(res["regressions"]["poly_para"]),
-        "poly_inv": _get_non_nan_scores(res["regressions"]["poly_inv_pin"]),
+        "poly_inv_pin": _get_non_nan_scores(res["regressions"]["poly_inv_pin"]),
     }
 
 
 trial_scores = {vidkey: get_scores(res) for vidkey, res in center_trial_data.items()}
-train_vid_scores = {vidkey: trial_scores[vidkey] for vidkey in train_set}
-test_vid_scores = {vidkey: trial_scores[vidkey] for vidkey in test_set}
 
 
 def concat_video_scores(
@@ -60,17 +68,44 @@ def concat_video_scores(
 ) -> dict[str, Float1D]:
     return {
         meth: np.concatenate([scores[meth] for scores in vid_scores.values()], axis=0)
-        for meth in ("lin", "poly", "poly_para", "poly_inv")
+        for meth in ("poly_inv_pin", "lin", "poly_para", "poly")
     }
 
 
-train_scores = concat_video_scores(train_vid_scores)
-test_scores = concat_video_scores(test_vid_scores)
-low_scores = concat_video_scores()  # fill this in here
+train_scores = concat_video_scores(
+    {vidkey: trial_scores[vidkey] for vidkey in train_set}
+)
+test_scores = concat_video_scores({vidkey: trial_scores[vidkey] for vidkey in test_set})
+low_scores = concat_video_scores({vidkey: trial_scores[vidkey] for vidkey in low_set})
+med_scores = concat_video_scores({vidkey: trial_scores[vidkey] for vidkey in med_set})
+hi_scores = concat_video_scores({vidkey: trial_scores[vidkey] for vidkey in hi_set})
+all_min = min(min(accs) for accs in test_scores.values())
+all_max = max(max(accs) for accs in test_scores.values())
 
-[
-    plt.hist(scores, label=method)
-    for method, scores in train_scores.items()
-    if method != "poly"
-]
-plt.legend()
+
+# %%
+def compare_histogram(concat_scores):
+    plt.title("Plume-Center Regressions Performance on Test Set")
+    bins = np.linspace(0, 1.5, 10)
+    plt.hist(
+        [-score for score in concat_scores.values()],
+        label=[full_methods[method] for method in concat_scores.keys()],
+        bins=list(bins),
+    )
+    plt.ylabel("Number of frames")
+    plt.xlabel("Relative Extrapolation Error")
+    plt.legend()
+
+
+# %% Figure 6
+compare_histogram(test_scores)
+print(
+    r"""Caption: The square-root regression best extrapolated
+      the plume's drift away from the point source,
+      followed closely by linear regression (95% confidence level)."""
+)
+
+# %% Optional investigation figures - combined test/train
+compare_histogram(low_scores)
+compare_histogram(med_scores)
+compare_histogram(hi_scores)

--- a/plumex/post/center.py
+++ b/plumex/post/center.py
@@ -1,8 +1,12 @@
+from collections import defaultdict
+from functools import partial
+from itertools import product
 from pathlib import Path
 
 import matplotlib.pyplot as plt
 import numpy as np
 from mitosis import load_trial_data
+from scipy.stats import ttest_ind
 
 from plumex.regression_pipeline import MultiRegressionResults
 from plumex.regression_pipeline import RegressionResults
@@ -84,7 +88,7 @@ all_max = max(max(accs) for accs in test_scores.values())
 
 
 # %%
-def compare_histogram(concat_scores):
+def compare_histogram(concat_scores: dict[str, Float1D]):
     plt.title("Plume-Center Regressions Performance on Test Set")
     bins = np.linspace(0, 1.5, 10)
     plt.hist(
@@ -106,6 +110,17 @@ print(
 )
 
 # %% Optional investigation figures - combined test/train
-compare_histogram(low_scores)
-compare_histogram(med_scores)
-compare_histogram(hi_scores)
+# compare_histogram(low_scores)
+# compare_histogram(med_scores)
+# compare_histogram(hi_scores)
+
+
+# %%
+# Produce p_vals for t-test
+pairwise_test = partial(ttest_ind, alternative="greater", equal_var=False)
+test_res = defaultdict(dict)
+for ((meth1, dat1), (meth2, dat2)) in product(test_scores.items(), test_scores.items()):
+    test_res[meth1][meth2] = pairwise_test(dat1, dat2)
+
+p_vals = np.array([[res.pvalue for res in d.values()] for d in test_res.values()])
+# %%

--- a/plumex/post/center.py
+++ b/plumex/post/center.py
@@ -1,0 +1,76 @@
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+from mitosis import load_trial_data
+
+from plumex.regression_pipeline import MultiRegressionResults
+from plumex.regression_pipeline import RegressionResults
+from plumex.types import Float1D
+
+center_trial_keys = {
+    "lo1": "677028",
+    "865": "b867ae",
+    "866": "5507db",
+    "867": "98c0dc",
+    "868": "ea68e7",
+    "869": "7314c2",
+    "871": "a42cc9",
+    "913": "bc1c70",
+    "914": "0d3391",
+    "916": "c41675",
+    "917": "9be0a9",
+    "919": "1e0610",
+    "920": "c0ab39",
+    "hi1": "729d03",
+    "hi2": "56a332",
+}
+train_set = ("lo1", "865", "866", "867", "871", "913", "914", "917", "919", "hi1")
+test_set = ("868", "869", "916", "920", "hi2")
+low_se = ("lo1", "865", "866", "867", "868")
+trials_folder = Path(__file__).absolute().parents[2] / "trials"
+center_trials_dir = trials_folder / "center-regress"
+center_trial_data: dict[str, MultiRegressionResults] = {
+    vidkey: load_trial_data(trialkey, trials_folder=center_trials_dir)[1]
+    for vidkey, trialkey in center_trial_keys.items()
+}
+
+
+def get_scores(res: MultiRegressionResults) -> dict[str, Float1D]:
+    """Get the scores from each frame, for each regression method"""
+
+    def _get_non_nan_scores(res: RegressionResults):
+        return res["val_acc"][res["non_nan_inds"]]
+
+    return {
+        "lin": _get_non_nan_scores(res["regressions"]["linear"]),
+        "poly": _get_non_nan_scores(res["regressions"]["poly"]),
+        "poly_para": _get_non_nan_scores(res["regressions"]["poly_para"]),
+        "poly_inv": _get_non_nan_scores(res["regressions"]["poly_inv_pin"]),
+    }
+
+
+trial_scores = {vidkey: get_scores(res) for vidkey, res in center_trial_data.items()}
+train_vid_scores = {vidkey: trial_scores[vidkey] for vidkey in train_set}
+test_vid_scores = {vidkey: trial_scores[vidkey] for vidkey in test_set}
+
+
+def concat_video_scores(
+    vid_scores: dict[str, dict[str, Float1D]]
+) -> dict[str, Float1D]:
+    return {
+        meth: np.concatenate([scores[meth] for scores in vid_scores.values()], axis=0)
+        for meth in ("lin", "poly", "poly_para", "poly_inv")
+    }
+
+
+train_scores = concat_video_scores(train_vid_scores)
+test_scores = concat_video_scores(test_vid_scores)
+low_scores = concat_video_scores()  # fill this in here
+
+[
+    plt.hist(scores, label=method)
+    for method, scores in train_scores.items()
+    if method != "poly"
+]
+plt.legend()

--- a/plumex/post/center.py
+++ b/plumex/post/center.py
@@ -123,4 +123,12 @@ for ((meth1, dat1), (meth2, dat2)) in product(test_scores.items(), test_scores.i
     test_res[meth1][meth2] = pairwise_test(dat1, dat2)
 
 p_vals = np.array([[res.pvalue for res in d.values()] for d in test_res.values()])
+
 # %%
+p_fig = plt.figure()
+ax = p_fig.add_subplot()
+ax.imshow(p_vals)
+ax.set_yticks(ticks=(0.0, 1.0, 2.0, 3.0), labels=test_res.keys())
+ax.set_xticks(ticks=(0.0, 1.0, 2.0, 3.0), labels=test_res.keys())
+ax.set_title("y axis is less than x axis:")
+p_fig.suptitle("Just a helpful graphic for typing in table")

--- a/plumex/post/fig1.py
+++ b/plumex/post/fig1.py
@@ -1,0 +1,86 @@
+# %%
+from collections import namedtuple
+from pathlib import Path
+from typing import Any
+from typing import Optional
+
+import matplotlib.pyplot as plt
+from ara_plumes import PLUME
+from ara_plumes.models import get_contour
+from mitosis import _load_trial_params
+
+from plumex.video_digest import _load_video
+from plumex.video_digest import _plot_contours
+
+# %%
+frame = 1000
+hexstr = "cb6956"
+trials_folder = Path(__file__).absolute().parents[2] / "trials"
+points_trials_folder = trials_folder / "center"
+tparams = _load_trial_params(hexstr, step=0, trials_folder=points_trials_folder)
+
+
+# %%
+def _single_img_range(kwargs: dict[str, Any], frame: int) -> dict[str, Any]:
+    kwargs.pop("img_range", None)
+    kwargs["frame"] = frame
+    # deprecated 'mean_smoothing'
+    if ckw := kwargs.get("circle_kw", False):
+        ckw.pop("mean_smoothing")
+    return kwargs
+
+
+_PlotData = namedtuple(
+    "_PlotData",
+    ["orig_center", "raw_im", "clean_im", "contour_kws", "center", "bottom", "top"],
+)
+
+
+def _mini_video_digest(
+    filename: str,
+    frame: int,
+    fixed_range: tuple[int, int] = (0, -1),
+    gauss_space_kws: Optional[dict[str, Any]] = None,
+    gauss_time_kws: Optional[dict[str, Any]] = None,
+    circle_kw: Optional[dict[str, Any]] = None,
+    contour_kws: Optional[dict[str, Any]] = None,
+) -> _PlotData:
+    raw_vid, orig_center = _load_video(filename)
+    clean_vid = PLUME.clean_video(
+        raw_vid,
+        fixed_range,
+        gauss_space_blur=True,
+        gauss_time_blur=True,
+        gauss_space_kws=gauss_space_kws,
+        gauss_time_kws=gauss_time_kws,
+    )
+    img_range = (frame, frame + 1)
+    center, bottom, top = PLUME.video_to_ROM(
+        clean_vid,
+        orig_center,
+        img_range,
+        concentric_circle_kws=circle_kw,
+        get_contour_kws=contour_kws,
+    )
+    return _PlotData(
+        orig_center,
+        raw_vid[frame],
+        clean_vid[frame],
+        contour_kws or {},
+        center,
+        bottom,
+        top,
+    )
+
+
+# %%
+# The first cell of fig 1, to be manually manipulated
+fig1a = plt.figure()
+example_data = _mini_video_digest(**_single_img_range(tparams, frame))
+contours = get_contour(example_data.clean_im, **example_data.contour_kws)
+_plot_contours(
+    fig1a.add_subplot(1, 1, 1),
+    example_data.clean_im,
+    example_data.orig_center,
+    contours,
+)

--- a/plumex/post/fig5.py
+++ b/plumex/post/fig5.py
@@ -1,0 +1,88 @@
+# %%
+import sys
+from pathlib import Path
+from typing import Any
+from typing import cast
+
+import matplotlib.pyplot as plt
+import numpy as np
+from ara_plumes.typing import Float2D
+from ara_plumes.typing import Frame
+from ara_plumes.typing import PlumePoints
+from mitosis import _load_trial_params
+from mitosis import load_trial_data
+
+from plumex.plotting import CMAP
+from plumex.regression_pipeline import _add_regression_to_plot
+from plumex.regression_pipeline import _plot_frame_points
+from plumex.regression_pipeline import regress_centerline
+from plumex.regression_pipeline import REGRESSION_METHODS
+from plumex.video_digest import _load_video
+from plumex.video_digest import _plot_frame
+from plumex.video_digest import _plot_learn_path
+
+frame = Frame(800)
+trials_folder = Path(__file__).absolute().parents[2] / "trials"
+# trail hash result data should ideally line upwith the inputs used by
+# center.py regression step.  But as this is a demonstration of method in
+# application, no validation data is reserved.
+example_trial = "cb6956"
+best_meth = "poly_inv_pin"
+points_trials_folder = trials_folder / "center"
+
+tdata = load_trial_data(example_trial, trials_folder=points_trials_folder)
+targs = _load_trial_params(example_trial, step=0, trials_folder=points_trials_folder)
+center = list(filter(lambda row: row[0] == frame, tdata[0]["data"]["center"]))[0][1]
+raw_vid, origin_fc = _load_video(targs["filename"])
+raw_frame = raw_vid[frame]
+
+
+def _mini_multireg_center(center: PlumePoints) -> Any:
+    meth_coeffs: dict[str, Float2D] = {}
+    for method in REGRESSION_METHODS:
+        meth_coeffs[method] = regress_centerline(
+            {"center": [(frame, center)]},
+            r_split=sys.maxsize,
+            regression_method=method,
+            poly_deg=2,
+            display=False,
+        )["data"]
+    return meth_coeffs
+
+
+meth_coeffs = _mini_multireg_center(center)
+best_c = meth_coeffs[best_meth]
+
+# %%
+fig5 = plt.figure(figsize=(5, 9))
+fig5.suptitle("Best regression method for center path")
+no_points = cast(PlumePoints, np.empty(shape=(0, 3)))
+ax0 = fig5.add_subplot(3, 1, 1)
+_plot_learn_path(ax0, raw_frame, center, no_points, no_points)
+# hack to make colors line up with second plot
+ax0.get_lines()[0].set_color(CMAP[0])
+ax0.set_xlabel("(a)")
+ax1 = fig5.add_subplot(3, 1, 2)
+y_max, x_max = raw_frame.shape
+origin_pc = (origin_fc[0], float(y_max - origin_fc[1]))
+_plot_frame_points(ax1, center, y_max, None, origin_fc)
+for meth_ind, (meth, coeffs) in enumerate(meth_coeffs.items()):
+    color = CMAP[2 + meth_ind]
+    _add_regression_to_plot(
+        ax1, coeffs.flatten(), meth, center, y_max, origin_fc, color
+    )
+ax1.set_xlim(ax0.get_xlim())
+ax1.set_ylim(ax0.get_ylim()[1], ax0.get_ylim()[0])
+ax1.set_xlabel("(b)")
+ax2 = fig5.add_subplot(3, 1, 3)
+_plot_frame(ax2, raw_frame)
+_add_regression_to_plot(
+    ax2, best_c.flatten(), best_meth, center, y_max, origin_fc, CMAP[4]
+)
+ax1.legend()
+# hack because _add_regression_to_plot meant for plot coordinate axis (positive up)
+for line in ax2.get_lines():
+    line.set_ydata(y_max - line.get_ydata())
+ax2.set_xlabel("(c)")
+fig5.tight_layout()
+fig5.subplots_adjust(top=0.95)

--- a/plumex/post/fig5.py
+++ b/plumex/post/fig5.py
@@ -54,15 +54,15 @@ meth_coeffs = _mini_multireg_center(center)
 best_c = meth_coeffs[best_meth]
 
 # %%
-fig5 = plt.figure(figsize=(5, 9))
+fig5 = plt.figure(figsize=(15, 4))
 fig5.suptitle("Best regression method for center path")
 no_points = cast(PlumePoints, np.empty(shape=(0, 3)))
-ax0 = fig5.add_subplot(3, 1, 1)
+ax0 = fig5.add_subplot(1, 3, 1)
 _plot_learn_path(ax0, raw_frame, center, no_points, no_points)
 # hack to make colors line up with second plot
 ax0.get_lines()[0].set_color(CMAP[0])
 ax0.set_xlabel("(a)")
-ax1 = fig5.add_subplot(3, 1, 2)
+ax1 = fig5.add_subplot(1, 3, 2)
 y_max, x_max = raw_frame.shape
 origin_pc = (origin_fc[0], float(y_max - origin_fc[1]))
 _plot_frame_points(ax1, center, y_max, None, origin_fc)
@@ -74,7 +74,7 @@ for meth_ind, (meth, coeffs) in enumerate(meth_coeffs.items()):
 ax1.set_xlim(ax0.get_xlim())
 ax1.set_ylim(ax0.get_ylim()[1], ax0.get_ylim()[0])
 ax1.set_xlabel("(b)")
-ax2 = fig5.add_subplot(3, 1, 3)
+ax2 = fig5.add_subplot(1, 3, 3)
 _plot_frame(ax2, raw_frame)
 _add_regression_to_plot(
     ax2, best_c.flatten(), best_meth, center, y_max, origin_fc, CMAP[4]
@@ -85,4 +85,4 @@ for line in ax2.get_lines():
     line.set_ydata(y_max - line.get_ydata())
 ax2.set_xlabel("(c)")
 fig5.tight_layout()
-fig5.subplots_adjust(top=0.95)
+fig5.subplots_adjust(top=0.90)

--- a/plumex/post/points.py
+++ b/plumex/post/points.py
@@ -1,0 +1,157 @@
+# %%
+from collections import namedtuple
+from pathlib import Path
+from typing import Any
+from typing import Optional
+
+import matplotlib.pyplot as plt
+from ara_plumes import PLUME
+from ara_plumes.models import get_contour
+from matplotlib.figure import Figure
+from mitosis import _load_trial_params
+from mitosis import load_trial_data
+
+from plumex.video_digest import _load_video
+from plumex.video_digest import _plot_contours
+from plumex.video_digest import _plot_frame
+from plumex.video_digest import _plot_learn_path
+
+
+frame = 500
+trials = {
+    "good": "cb6956",
+    "no smoothing": "cee527",
+    "extra smoothing": "1c55e1",
+    "two contours": "b4dc87",
+}
+trials_folder = Path(__file__).absolute().parents[2] / "trials"
+points_trials_folder = trials_folder / "center"
+
+trial_info = {
+    trial_tag: (
+        load_trial_data(hexstr, trials_folder=points_trials_folder),
+        _load_trial_params(hexstr, step=0, trials_folder=points_trials_folder),
+    )
+    for trial_tag, hexstr in trials.items()
+}
+
+
+_PlotData = namedtuple(
+    "_PlotData",
+    ["orig_center", "raw_im", "clean_im", "contour_kws", "center", "bottom", "top"],
+)
+
+
+def _mini_video_digest(
+    filename: str,
+    frame: int,
+    fixed_range: tuple[int, int] = (0, -1),
+    gauss_space_kws: Optional[dict[str, Any]] = None,
+    gauss_time_kws: Optional[dict[str, Any]] = None,
+    circle_kw: Optional[dict[str, Any]] = None,
+    contour_kws: Optional[dict[str, Any]] = None,
+) -> _PlotData:
+    raw_vid, orig_center = _load_video(filename)
+    clean_vid = PLUME.clean_video(
+        raw_vid,
+        fixed_range,
+        gauss_space_blur=True,
+        gauss_time_blur=True,
+        gauss_space_kws=gauss_space_kws,
+        gauss_time_kws=gauss_time_kws,
+    )
+    img_range = (frame, frame + 1)
+    center, bottom, top = PLUME.video_to_ROM(
+        clean_vid,
+        orig_center,
+        img_range,
+        concentric_circle_kws=circle_kw,
+        get_contour_kws=contour_kws,
+    )
+    return _PlotData(
+        orig_center,
+        raw_vid[frame, ...],
+        clean_vid[frame, ...],
+        contour_kws or {},
+        center,
+        bottom,
+        top,
+    )
+
+
+# %%
+def _single_img_range(kwargs: dict[str, Any], frame: int) -> dict[str, Any]:
+    kwargs.pop("img_range", None)
+    kwargs["frame"] = frame
+    # deprecated 'mean_smoothing'
+    if ckw := kwargs.get("circle_kw", False):
+        ckw.pop("mean_smoothing")
+    return kwargs
+
+
+# %%
+
+trial_info = {
+    trial_tag: (data, _single_img_range(kwargs, frame))
+    for trial_tag, (data, kwargs) in trial_info.items()
+}
+trial_plot_data = {
+    trial_tag: _mini_video_digest(**kwargs)
+    for trial_tag, (_, kwargs) in trial_info.items()
+}
+
+
+# %%
+def _compare_step1_plot(trial_plot_data: dict[str, _PlotData]) -> Figure:
+    n_variants = len(trial_plot_data)
+    superfig = plt.figure(figsize=(10, 1.3 * n_variants))
+    gs = superfig.add_gridspec(n_variants, 5)
+    for superrow, (variant_name, exptup) in enumerate(trial_plot_data.items()):
+        contours = get_contour(exptup.clean_im, **exptup.contour_kws)
+        ax0 = superfig.add_subplot(gs[superrow, 0])
+        ax0.set_ylabel(variant_name)
+        _plot_frame(ax0, exptup.raw_im)
+        _plot_frame(superfig.add_subplot(gs[superrow, 1]), exptup.clean_im)
+        _plot_contours(
+            superfig.add_subplot(gs[superrow, 2]),
+            exptup.clean_im,
+            exptup.orig_center,
+            contours,
+        )
+        _plot_learn_path(
+            superfig.add_subplot(gs[superrow, 3]),
+            exptup.clean_im,
+            exptup.center[0][1],
+            exptup.top[0][1],
+            exptup.bottom[0][1],
+        )
+        _plot_learn_path(
+            superfig.add_subplot(gs[superrow, 4]),
+            exptup.raw_im,
+            exptup.center[0][1],
+            exptup.top[0][1],
+            exptup.bottom[0][1],
+        )
+
+    return superfig
+
+
+# %% Figure 2
+fig2 = _compare_step1_plot({k: v for k, v in trial_plot_data.items() if k == "good"})
+fig2.suptitle("Data reduction process for plume film")
+fig2.tight_layout()
+fig2.subplots_adjust(top=0.80)
+fig2.axes[0].set_ylabel("")
+fig2.axes[0].set_xlabel("(a)")
+fig2.axes[1].set_xlabel("(b)")
+fig2.axes[2].set_xlabel("(c)")
+fig2.axes[3].set_xlabel("(d)")
+fig2.axes[4].set_xlabel("(e)")
+pass
+# %% Figure 4
+fig4 = _compare_step1_plot({k: v for k, v in trial_plot_data.items()})
+fig4.tight_layout()
+fig4.subplots_adjust(top=0.95)
+fig4.suptitle("How sensitive are the plume points to the extraction parameters?")
+pass
+# %%

--- a/plumex/post/points.py
+++ b/plumex/post/points.py
@@ -17,12 +17,11 @@ from plumex.video_digest import _plot_frame
 from plumex.video_digest import _plot_learn_path
 
 
-frame = 500
+frame = 838
 trials = {
     "good": "cb6956",
-    "no smoothing": "cee527",
-    "extra smoothing": "1c55e1",
-    "two contours": "b4dc87",
+    "extra blur": "430130",
+    "one contour": "76b9db",
 }
 trials_folder = Path(__file__).absolute().parents[2] / "trials"
 points_trials_folder = trials_folder / "center"
@@ -154,4 +153,5 @@ fig4.tight_layout()
 fig4.subplots_adjust(top=0.95)
 fig4.suptitle("How sensitive are the plume points to the extraction parameters?")
 pass
+
 # %%

--- a/plumex/post/points.py
+++ b/plumex/post/points.py
@@ -70,8 +70,8 @@ def _mini_video_digest(
     )
     return _PlotData(
         orig_center,
-        raw_vid[frame, ...],
-        clean_vid[frame, ...],
+        raw_vid[frame],
+        clean_vid[frame],
         contour_kws or {},
         center,
         bottom,

--- a/plumex/video_digest.py
+++ b/plumex/video_digest.py
@@ -52,13 +52,7 @@ def create_plumepoints(
     if contour_kws is None:
         contour_kws = {}
 
-    origin_filename = filename + "_ctr.pkl"
-    with open(PICKLE_PATH / origin_filename, "rb") as fh:
-        origin = pickle.load(fh)
-    np_filename = filename[:-3] + "pkl"  # replace mov with pkl
-    with open(PICKLE_PATH / np_filename, "rb") as fh:
-        raw_vid = pickle.load(fh)
-    orig_center = (int(origin[0]), int(origin[1]))
+    raw_vid, orig_center = _load_video(filename)
     clean_vid = PLUME.clean_video(
         raw_vid,
         fixed_range,
@@ -78,6 +72,17 @@ def create_plumepoints(
         raw_vid, clean_vid, orig_center, center, bottom, top, 15, contour_kws
     )
     return {"main": None, "data": {"center": center, "bottom": bottom, "top": top}}
+
+
+def _load_video(filename: str) -> tuple[GrayVideo, tuple[int, int]]:
+    origin_filename = filename + "_ctr.pkl"
+    with open(PICKLE_PATH / origin_filename, "rb") as fh:
+        origin = pickle.load(fh)
+    np_filename = filename[:-3] + "pkl"  # replace mov with pkl
+    with open(PICKLE_PATH / np_filename, "rb") as fh:
+        raw_vid = pickle.load(fh)
+    orig_center = (int(origin[0]), int(origin[1]))
+    return raw_vid, orig_center
 
 
 def visualize_points(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
   "pysindy[cvxpy] @ git+https://github.com/dynamicslab/pysindy@a43e217",
   "matplotlib",
   "pysindy-experiments @ git+https://github.com/Jacob-Stevens-Haas/gen-experiments@cbaa059",
-  "ara_plumes @ git+https://github.com/Jacob-Stevens-Haas/ARA-Plumes@0.6.0",
+  "ara_plumes @ git+https://github.com/Jacob-Stevens-Haas/ARA-Plumes@0.7.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "pysindy-plume-experiments"
 dynamic = ["version"]
 dependencies = [
-  "mitosis>=0.5.2",
+  "mitosis>=0.5.5",
   "pydmd",
   "pysindy[cvxpy] @ git+https://github.com/dynamicslab/pysindy@a43e217",
   "matplotlib",


### PR DESCRIPTION
These changes points.py, center.py, and fig5.py, which generate all figures for step 1 and step 2a.  They should be directly runnable, via: 
```python
python -m plumex.post
```
in any environment where plumex is installed.  Images of the results have been added to the notes google doc.