### PR TITLE
enhance: smooth edge regression function by adding more points to plot.

### DIFF
--- a/plumex/post/edge_figs.py
+++ b/plumex/post/edge_figs.py
@@ -9,9 +9,9 @@ import numpy as np
 from ara_plumes.models import flatten_edge_points
 from ara_plumes.typing import PlumePoints
 
-from .post_utils import _visualize_multi_edge_fits
-from .post_utils import create_edge_func
-from .post_utils import RegressionData
+from plumex.post.post_utils import _visualize_multi_edge_fits
+from plumex.post.post_utils import create_edge_func
+from plumex.post.post_utils import RegressionData
 from plumex.config import data_lookup
 from plumex.regress_edge import create_sin_func
 from plumex.video_digest import _load_video

--- a/plumex/post/edge_figs.py
+++ b/plumex/post/edge_figs.py
@@ -4,6 +4,7 @@ from typing import List
 from typing import Tuple
 
 import matplotlib.pyplot as plt
+from matplotlib.figure import Figure
 import mitosis
 import numpy as np
 from ara_plumes.models import flatten_edge_points
@@ -208,8 +209,53 @@ def _create_fig1c():
     ax.tick_params(left=False, labelleft=False, bottom=False, labelbottom=False)
     return fig
 
+def plot_param_hist_new(top_param_hist, bot_param_hist, titles, main_title) -> Figure:
+    num_cols = top_param_hist.shape[1]
+    fig, axs = plt.subplots(2,num_cols,figsize = (16,6))
+    axs = axs.flatten()
 
-_create_fig1c()
-_create_fig1d()
-_create_fig2b_raw()
-_create_fig2b_regression()
+    top_param_opt = top_param_hist.mean(axis=0)
+    bot_param_opt = bot_param_hist.mean(axis=0)
+
+    for idx in range(num_cols):
+        axs[idx].hist(top_param_hist[:,idx], bins=50,density=True,alpha=0.8)
+        axs[idx].set_title(titles[idx],fontsize=15)
+        if idx==0:
+            axs[idx].set_ylabel("Top params", fontsize=15)
+        axs[idx].axvline(top_param_opt[idx],c="red",linestyle="--")
+
+
+    for idx in range(num_cols):
+        axs[idx+num_cols].hist(bot_param_hist[:,idx],bins=50,density=True, alpha=0.8)
+        axs[idx+num_cols].set_xlabel("val")    
+        if idx==0:
+            axs[idx+num_cols].set_ylabel("Bottom params", fontsize=15)
+        axs[idx+num_cols].axvline(bot_param_opt[idx],c="red", linestyle="--")
+
+    fig.suptitle(main_title, fontsize=20)
+    plt.tight_layout()
+    return fig
+
+
+
+def _create_step2b_hist():
+    edge_regress_hi920_hash = "485d19"
+    titles = [r"$A$", r"$\omega$", r"$\gamma$", r"$B$",r"$C$", r"$D$"]
+
+    _,edge_data = mitosis.load_trial_data(
+        hexstr=edge_regress_hi920_hash, trials_folder=trials_folder / "edge-regress"
+    )
+    top_coeffs = edge_data["accs"]["top"]["sinusoid"]["coeffs"]
+    bot_coeffs = edge_data["accs"]["bot"]["sinusoid"]["coeffs"]
+
+    non_nan_top_coeffs = top_coeffs[~np.isnan(top_coeffs)[:, 0]]
+    non_nan_bot_coeffs = bot_coeffs[~np.isnan(bot_coeffs)[:, 0]]
+
+    plot_param_hist_new(non_nan_top_coeffs,non_nan_bot_coeffs,titles=titles,main_title="Sinusoid Parameter Histogram")
+
+
+# _create_fig1c()
+# _create_fig1d()
+# _create_fig2b_raw()
+# _create_fig2b_regression()
+_create_step2b_hist()

--- a/plumex/post/post_utils.py
+++ b/plumex/post/post_utils.py
@@ -94,18 +94,14 @@ def _construct_rxy_from_center_fit(
     """
     Allows for more interpolating points
     """
-    rxy = np.array([indep_data]*3).T
+    rxy = np.array([indep_data] * 3).T
     if regression_method == "poly_para":
         return center_fit_func(rxy)
-    else: 
+    else:
         rxy = center_fit_func(rxy)
-        r_vals = np.linalg.norm(rxy[:,1:],axis=1)
-        rxy[:,0]=r_vals
+        r_vals = np.linalg.norm(rxy[:, 1:], axis=1)
+        rxy[:, 0] = r_vals
         return rxy
-
-
-
-
 
 
 def _visualize_multi_edge_fits(
@@ -173,22 +169,18 @@ def _visualize_multi_edge_fits(
             )
             raw_center_points[:, 1:] -= orig_center_fc
             if center_fit_method == "poly_para":
-                r_min = np.min(raw_center_points[:,0])*1.5
-                r_max = np.max(raw_center_points[:,0])*1.5
-                r_vals = np.linspace(r_min,r_max,101)
+                r_min = np.min(raw_center_points[:, 0]) * 1.5
+                r_max = np.max(raw_center_points[:, 0]) * 1.5
+                r_vals = np.linspace(r_min, r_max, 101)
                 fit_centerpoints_dc = _construct_rxy_from_center_fit(
-                    r_vals,
-                    center_fit_func,
-                    center_fit_method
+                    r_vals, center_fit_func, center_fit_method
                 )
             else:
-                x_min = np.min(raw_center_points[:,1])*2
-                x_max = np.max(raw_center_points[:,1])*1.5
-                x_vals = np.linspace(x_min,x_max,101)
+                x_min = np.min(raw_center_points[:, 1]) * 2
+                x_max = np.max(raw_center_points[:, 1]) * 1.5
+                x_vals = np.linspace(x_min, x_max, 101)
                 fit_centerpoints_dc = _construct_rxy_from_center_fit(
-                    x_vals,
-                    center_fit_func,
-                    center_fit_method
+                    x_vals, center_fit_func, center_fit_method
                 )
             raw_center_points[:, 1:] += orig_center_fc
             fit_centerpoints_dc[:, 1:] += orig_center_fc


### PR DESCRIPTION
Fixed issue of smooth edge plots when linear regression is done. 

`_construct_rxy_from_center_fit` allows to use learned center fit function more easily at points not observed in `raw_center_points`.


### Before
<img width="1501" alt="fig1dOLD" src="https://github.com/user-attachments/assets/ad37b42b-6ea8-49d8-8567-48546c4a29f3">

### After

![fig1d](https://github.com/user-attachments/assets/d40e6077-aadf-4eaa-8c96-d13bf836da1e)

### Also fixed figure in paper

![step2b_attached_center](https://github.com/user-attachments/assets/7db51165-31b4-4522-856a-283d04c8bfec)


